### PR TITLE
Prune dryrun option

### DIFF
--- a/bin/prune.sh
+++ b/bin/prune.sh
@@ -71,7 +71,7 @@ for host in $HOSTS; do
             if [ -f $snapshot/c/EXPIRY ]; then
                 EXPIRY=$(cat $snapshot/c/EXPIRY 2> /dev/null)
                 if [ $(date +%s) -gt $EXPIRY ]; then
-                    logMessage 1 $LOGFILE "Info: Removing snapshot ${snapshot}."
+                    logMessage 1 $LOGFILE "$DRYRUN Removing snapshot ${snapshot}."
                     SNAPSHOT=$(basename $snapshot)
                     if [ -n "$DRYRUN" ] ; then
                         echo $DRYRUN zfs destroy ${ZPOOL_NAME}/hosts/${host}@${SNAPSHOT}


### PR DESCRIPTION
This is a dry-run option for prune.sh:  show what snapshots would be pruned, but don't actually do it.  It's nice to see what would be done, and be reassured that it's not gonna eat everything. :-)

Changing the argument processing in this one does bring up the question of the other commands, and I'm not sure how that fits in with your plans to eventually rewrite in Python.  Perhaps you don't want to too involved in the Bash commands right now...but this _is_ handy.

Also, not sure how you feel about logging to stderr and the verbose log messages.  Feel free to ignore those if it's not your style.

Thanks,
Hugh
