### PR TITLE
A simple way to temporarily exclude a host from snapshot pruning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ retention policy set _DISABLED=true_ in ``./hosts/<hostname>/c/backup.conf``.
 This is the preferred method for host removal as it allows the old backups to
 naturally expire.
 
+To temporarily disable snapshot pruning for a single host, touch the
+file ``./hosts/<hostname>/NO_SNAPSHOT_PRUNING_PLEASE``.  This will
+prevent prune.sh from deleting snapshots for that host.
+
 ### Running an ad hoc backup of a single host
 
 ``./bin/backup.sh <hostname> <annotation> <expiry-in-days>``

--- a/bin/prune.sh
+++ b/bin/prune.sh
@@ -68,6 +68,10 @@ fi
 for host in $HOSTS; do
     logMessage 1 $LOGFILE "Info: Pruning snapshots for ${host}."
     if [ -d ${HOSTS_DIR}${host}/.zfs/snapshot ]; then
+	if [ -f ${HOSTS_DIR}${host}/NO_SNAPSHOT_PRUNING_PLEASE ] ; then
+	    echo "${HOSTS_DIR}${host}/NO_SNAPSHOT_PRUNING_PLEASE exists; refusing to prune snapshots for this host!"
+	    continue
+	fi
         SNAPSHOTS=$(find ${HOSTS_DIR}${host}/.zfs/snapshot -maxdepth 1 -mindepth 1)
         for snapshot in $SNAPSHOTS; do
             if [ -f $snapshot/c/EXPIRY ]; then


### PR DESCRIPTION
Hi there -- this is a very simple way to temporarily exclude a host from snapshot pruning, by creating the file `./hosts/<hostname>/NO_SNAPSHOT_PRUNING_PLEASE`.  It ain't elegant, but it works for me.  

There are a couple use cases for me:
- A workstation is being reinstalled; in the meantime, I don't want its old backups to fall off the edge.
- I have some simple Samba servers in front of scientific instruments runninng Windows, and I back up the Samba shares with Adlibre to get the data.  Occasionally those instruments are turned off, sometimes for extended periods (weeks), and I don't want the old backups to fall off the edge.

I'm not sure if this will fit in with your plans for Adlibre, or if the mechanism is something you like (I like the file 'cos it's nice and obvious, but you may want to put everything in backup.conf), but on the off chance it's useful here you go.

Thanks for your time!
