### PR TITLE
Don't use $HOST until it's set.

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -11,8 +11,6 @@ CWD="$(dirname $0)/"
 . ${CWD}functions.sh;
 
 HOSTS_DIR="/${ZPOOL_NAME}/hosts/"
-LOCKFILE="/var/run/$(basename $0 | sed s/\.sh//)-${HOST}.pid"
-LOGFILE="${HOSTS_DIR}${HOST}/l/backup.log"
 DRYRUN=
 FORCE=
 
@@ -49,6 +47,8 @@ done
 
 HOST=$1
 ANNOTATION=${2-none}
+LOCKFILE="/var/run/$(basename $0 | sed s/\.sh//)-${HOST}.pid"
+LOGFILE="${HOSTS_DIR}${HOST}/l/backup.log"
 # source host config
 
 if [ ! ${HOST} ]; then


### PR DESCRIPTION
The new argument parsing leaves $HOST unset; this leaves $LOCKFILE and $LOGFILE incorrect, and backup.sh exits with an error:

```
tee: /tank/rsync/hosts//l/backup.log: No such file or directory 
/tank/rsync/bin/backup.sh: cannot create /tank/rsync/hosts//l/backup.log: No such file or directory
```
