### PR TITLE
Prevent prune.sh from stopping at first host with disabled pruning.

### DIFF
--- a/bin/prune.sh
+++ b/bin/prune.sh
@@ -76,7 +76,8 @@ for HOST in $HOSTS; do
     # Check to see if the host prune is disabled.
     if [ "${PRUNE}" == "false" ] && [ -z "$FORCE" ];  then
         logMessage 1 $LOGFILE "Info: ${HOST} prune disabled by config."
-        break
+        PRUNE=true		# reset for the next pass through
+	continue
     else
         logMessage 1 $LOGFILE "Info: Pruning snapshots for ${HOST}."
     fi


### PR DESCRIPTION
I didn't notice this before, but using "break" instead of "continue" means the whole pruning stops at the first host that has "PRUNE=false".  Also, $PRUNE isn't reset between passes, so I've set it by hand to "true".
