### PR TITLE
shorten snapshot paths to fit 88 char limit in iocage jails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+hosts/
+h/
 hosts
+*.swp

--- a/bin/add-host.sh
+++ b/bin/add-host.sh
@@ -18,19 +18,28 @@ if [ ! $HOST ]; then
 fi
 
 # Create hosts subvolume
-if [ ! -d "/${POOL_NAME}/hosts/" ]; then
-    storageCreate $POOL_TYPE ${POOL_NAME}/hosts
+if [ ${HACK88} == '1' ]; then
+    HOSTS_DIR='h'
+    if [ ! -d "${MOUNT_POINT}/h/" ]; then
+        storageCreate $POOL_TYPE ${POOL_NAME}/h
+        ln -s ${MOUNT_POINT}/h ${MOUNT_POINT}/hosts
+    fi
+else
+    HOSTS_DIR='hosts'
+    if [ ! -d "${MOUNT_POINT}/hosts/" ]; then
+        storageCreate $POOL_TYPE ${POOL_NAME}/hosts
+    fi
 fi
 
 # Create host subvolume
-if [ ! -d "/${POOL_NAME}/hosts/${HOST}" ]; then
-    storageCreate $POOL_TYPE ${POOL_NAME}/hosts/${HOST}
-    mkdir /${POOL_NAME}/hosts/${HOST}/c
-    mkdir /${POOL_NAME}/hosts/${HOST}/d
-    mkdir /${POOL_NAME}/hosts/${HOST}/l
-    cp /${POOL_NAME}/etc/host_default.conf /${POOL_NAME}/hosts/${HOST}/c/backup.conf
+if [ ! -d "/${MOUNT_POINT}/${HOSTS_DIR}/${HOST}" ]; then
+    storageCreate $POOL_TYPE ${POOL_NAME}/${HOSTS_DIR}/${HOST}
+    mkdir ${MOUNT_POINT}/${HOSTS_DIR}/${HOST}/c
+    mkdir ${MOUNT_POINT}/${HOSTS_DIR}/${HOST}/d
+    mkdir ${MOUNT_POINT}/${HOSTS_DIR}/${HOST}/l
+    cp ${MOUNT_POINT}/etc/host_default.conf ${MOUNT_POINT}/${HOSTS_DIR}/${HOST}/c/backup.conf
     if [ "${POOL_TYPE}" == "btrfs" ]; then 
-        mkdir -p /${POOL_NAME}/hosts/${HOST}/.btrfs/snapshot
+        mkdir -p ${MOUNT_POINT}/hosts/${HOST}/.btrfs/snapshot
     fi
 else
     echo "Error: Host already exists."

--- a/bin/backup-runner.sh
+++ b/bin/backup-runner.sh
@@ -10,9 +10,13 @@ CWD="$(dirname $0)/"
 # Source Functions
 . ${CWD}functions.sh;
 
-HOSTS_DIR="/${POOL_NAME}/hosts/"
+if [ ${HACK88} == '1' ]; then
+    HOSTS_DIR="${MOUNT_POINT}/h/"
+else
+    HOSTS_DIR="${MOUNT_POINT}/hosts/"
+if
 LOCKFILE="/var/run/$(basename $0 | sed s/\.sh//).pid"
-LOGFILE="/${POOL_NAME}/logs/backup.log"
+LOGFILE="${MOUNT_POINT}/logs/backup.log"
 
 if [ ! $(whoami) = "root" ]; then
     echo "Error: Must run as root."

--- a/bin/list-backups.sh
+++ b/bin/list-backups.sh
@@ -10,7 +10,11 @@ CWD="$(dirname $0)/"
 # Source Functions
 . ${CWD}functions.sh;
 
-HOSTS_DIR="/${POOL_NAME}/hosts/"
+if [ ${HACK88} == '1' ]; then
+    HOSTS_DIR="${MOUNT_POINT}/h/"
+else
+    HOSTS_DIR="${MOUNT_POINT}/hosts/"
+fi
 
 if [ ! $(whoami) = "root" ]; then
     echo "Error: Must run as root."
@@ -34,7 +38,12 @@ for host in $HOSTS; do
             SNAPSHOT=$(basename $snapshot)
             EXPIRY=$(cat $snapshot/c/EXPIRY 2> /dev/null)
             ANNOTATION=$(cat $snapshot/c/ANNOTATION 2> /dev/null)
-            echo "$host $SNAPSHOT $EXPIRY \"$ANNOTATION\""
+            if [ "$HACK88" == "1" ]; then
+                . ${HOSTS_DIR}${host}/.zfs/snapshot/$SNAPSHOT/l/snap_data
+                echo "$host ${SNAPSHOT}:${SNAP_NAME} $EXPIRY \"$ANNOTATION\""
+            else
+                echo "$host $SNAPSHOT $EXPIRY \"$ANNOTATION\""
+            fi
         done
     fi
 done

--- a/bin/prune.sh
+++ b/bin/prune.sh
@@ -12,9 +12,13 @@ CWD="$(dirname $0)/"
 # Source Functions
 . ${CWD}functions.sh;
 
-HOSTS_DIR="/${POOL_NAME}/hosts/"
+if [ ${HACK88} == '1' ]; then
+    HOSTS_DIR="${MOUNT_POINT}/h/"
+else
+    HOSTS_DIR="${MOUNT_POINT}/hosts/"
+fi
 LOCKFILE="/var/run/$(basename $0 | sed s/\.sh//).pid"
-LOGFILE="/${POOL_NAME}/logs/backup.log"
+LOGFILE="${MOUNT_POINT}/logs/backup.log"
 DRYRUN=
 FORCE=
 
@@ -91,9 +95,9 @@ for HOST in $HOSTS; do
                     logMessage 1 $LOGFILE "Info: Removing snapshot ${snapshot}."
                     SNAPSHOT=$(basename $snapshot)
                     if [ -n "$DRYRUN" ] ; then
-                        echo $DRYRUN destroy ${POOL_NAME}/hosts/${HOST} ${SNAPSHOT}
+                        echo $DRYRUN destroy ${POOL_NAME}/${HOSTS_DIR}/${HOST} ${SNAPSHOT}
                     else
-                        storageDelete $POOL_TYPE ${POOL_NAME}/hosts/${HOST} ${SNAPSHOT}
+                        storageDelete $POOL_TYPE ${POOL_NAME}/${HOSTS_DIR}/${HOST} ${SNAPSHOT}
                     fi
                 fi
             fi

--- a/etc/backup.conf
+++ b/etc/backup.conf
@@ -2,10 +2,11 @@
 
 LOG_LEVEL=0
 ECHO_LOG='1'
-POOL_NAME='backup'  # this needs to be mounted at root level
-POOL_TYPE='btrfs'  # btrfs or zfs
-RSYNC_BIN='/usr/bin/rsync'
-RSYNC_ARGS='-a --numeric-ids --hard-links --compress --delete-after --delete-excluded --fuzzy'
+POOL_NAME='tank1/data/backups/backupdata' 
+POOL_TYPE='zfs'  # btrfs or zfs
+HACK88='1'
+RSYNC_BIN='/usr/local/bin/rsync'
+RSYNC_ARGS='-a --numeric-ids --compress --delete-after --delete-excluded --fuzzy'
 SSH_USER='root'
 EXCLUDE='/dev /proc /sys /tmp /var/tmp /var/run /selinux /cgroups lost+found'
 BACKUP_PATHS='/'
@@ -19,3 +20,10 @@ NSCA_ENABLED='false'  # true or false
 NSCA_SERVER='monitor.example.com'
 NSCA_BIN='/usr/sbin/send_nsca'
 NSCA_CFG='/etc/nagios/send_nsca.cfg'
+
+# the mount point might not be the same as POOL_NAME for zfs..fixme for btrfs
+if [ ${POOL_TYPE} = 'zfs' ] ; then
+    MOUNT_POINT=$(zfs get -H mountpoint ${POOL_NAME}|awk '{print $3}')
+else
+    MOUNT_POINT="/${POOL_NAME}"
+fi

--- a/etc/host_default.conf
+++ b/etc/host_default.conf
@@ -4,7 +4,9 @@ EXCLUDE_ADDITIONAL=''
 RSYNC_ADDITIONAL_ARGS=''
 #RSYNC_HOST= # Override hostname
 #BACKUP_PATHS=''
-#EXPIRY='' # Backup expiry in days
+EXPIRY='10' # Backup expiry in days
 #SNAPSHOT_ON_ERROR=false # Set this to true when you want to snapshot backups that encounter errors
 #DISABLED=false # Set this to true when you want to disable backups, yet let existing backups expire
 #PRUNE=false # Set this to false when you do not want backups to expire
+
+TRANSFER_METHOD='rsyncd'


### PR DESCRIPTION
FreeBSD has a long standing limitation that mount paths be 88 characters or less. With adlbre-backup running inside an iocage jail this limit makes the zfs snapshots unmountable since the mount path for the jail adds at least 27 characters to the path. I got around this by giving snapshots 2 digit numeric names and renaming hosts to h. The original snapshot name is stored in l/snap_data.

A side benefit of this change is that the zfs mountpoint can differ from the dataset name. My data set has a longish name to fit my convention for jailed data. It gets mounted on /b.

The changes are activated by HACK88=1 in backup.conf.

RP