### PR TITLE
Add include pattern support for rsync

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -79,8 +79,17 @@ if [ "${DISABLED}" == "true" ] && [ -z "$FORCE" ];  then
     exit 0
 fi
 
+# disable shell globbing to properly handle rsync patterns
+set -f
+
 # expand excludes (with support for strings with escaped spaces)
 eval "for e in $EXCLUDE $EXCLUDE_ADDITIONAL; do RSYNC_EXCLUDES=\"\$RSYNC_EXCLUDES --exclude='\${e}'\"; done"
+
+# expand includes (with support for strings with escaped spaces)
+eval "for i in $INCLUDE $INCLUDE_ADDITIONAL; do RSYNC_INCLUDES=\"\$RSYNC_INCLUDES --exclude='\${i}'\"; done"
+
+# enable shell globbing
+set +f
 
 # Generate rsync compatible backup path arguments
 for P in $BACKUP_PATHS; do
@@ -104,7 +113,7 @@ echo $ANNOTATION > ${HOSTS_DIR}${HOST}/c/ANNOTATION
 
 STARTTIME=$(date +%s)
 
-RSYNC_CMD="${RSYNC_BIN} ${RSYNC_ARGS} ${RSYNC_ADDITIONAL_ARGS} ${RSYNC_EXCLUDES} ${SSH_USER}@${RSYNC_HOST-${HOST}}${RSYNC_BACKUP_PATHS} ${HOSTS_DIR}${HOST}/d/"
+RSYNC_CMD="${RSYNC_BIN} ${RSYNC_ARGS} ${RSYNC_ADDITIONAL_ARGS} ${RSYNC_INCLUDES} ${RSYNC_EXCLUDES} ${SSH_USER}@${RSYNC_HOST-${HOST}}${RSYNC_BACKUP_PATHS} ${HOSTS_DIR}${HOST}/d/"
 logMessage 1 $LOGFILE "Running: $RSYNC_CMD"
 CMD=$(eval $RSYNC_CMD 2>&1;)
 RSYNC_RETVAL=$?

--- a/etc/backup.conf
+++ b/etc/backup.conf
@@ -8,9 +8,10 @@ RSYNC_BIN='/usr/bin/rsync'
 RSYNC_ARGS='-a --numeric-ids --hard-links --compress --delete-after --delete-excluded --fuzzy --inplace'
 SSH_USER='root'
 EXCLUDE='/dev /proc /sys /tmp /var/tmp /var/run /selinux /cgroups lost+found'
+INCLUDE=''
 BACKUP_PATHS='/'
 EXPIRY='28' # Default backup expiry (in days)
-SSH_KEY=~root/.ssh/id_rsa.pub 
+SSH_KEY=~root/.ssh/id_rsa.pub
 SNAPSHOT_ON_ERROR=false  # Snapshot after rsync errors
 PRUNE=true  # Prune old expired backup snapshots
 

--- a/etc/host_default.conf
+++ b/etc/host_default.conf
@@ -1,6 +1,7 @@
 # Host Template / Skel config
 
 EXCLUDE_ADDITIONAL=''
+INCLUDE_ADDITIONAL=''
 RSYNC_ADDITIONAL_ARGS=''
 #RSYNC_HOST= # Override hostname
 #BACKUP_PATHS=''


### PR DESCRIPTION
I've extended the options to support rsync's include patterns. I've encountered a scenario where I wanted to exclude a whole subtree (/usr), but include only a single child directory and its subtree (/usr/local).

This PR adds support for include patterns similar to exclude patterns, plus fixes shell globbing, which interfered with patterns like _/usr/**_.