### PR TITLE
Fix snapshot timestamp

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -125,15 +125,15 @@ if [ "$RSYNC_RETVAL" = "0" ] || [ "${SNAPSHOT_ON_ERROR}" == "true" ]; then
 
     # Create snapshot
     if [ "$RSYNC_RETVAL" = "0" ]; then
-        SNAP_NAME="@$(date +"%F-%X-%s")"
+        SNAP_NAME="@$(date +"%F-%R-%s")"
         echo "successful" > $STATUSFILE
         logMessage 1 $LOGFILE "Backup successful: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     elif [ "$RSYNC_RETVAL" = "23" ] || [ "$RSYNC_RETVAL" = "24" ]; then
-        SNAP_NAME="@$(date +"%F-%X-%s")-partial"
+        SNAP_NAME="@$(date +"%F-%R-%s")-partial"
         echo "partial" > $STATUSFILE
         logMessage 2 $LOGFILE "Partial Backup: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     else
-        SNAP_NAME="@$(date +"%F-%X-%s")-failed"
+        SNAP_NAME="@$(date +"%F-%R-%s")-failed"
         echo "failed" > $STATUSFILE
         logMessage 3 $LOGFILE "Backup failed: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     fi

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -125,15 +125,15 @@ if [ "$RSYNC_RETVAL" = "0" ] || [ "${SNAPSHOT_ON_ERROR}" == "true" ]; then
 
     # Create snapshot
     if [ "$RSYNC_RETVAL" = "0" ]; then
-        SNAP_NAME="@$(date +"%F-%R-%s")"
+        SNAP_NAME="@$(date +"%F-%T-%s")"
         echo "successful" > $STATUSFILE
         logMessage 1 $LOGFILE "Backup successful: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     elif [ "$RSYNC_RETVAL" = "23" ] || [ "$RSYNC_RETVAL" = "24" ]; then
-        SNAP_NAME="@$(date +"%F-%R-%s")-partial"
+        SNAP_NAME="@$(date +"%F-%T-%s")-partial"
         echo "partial" > $STATUSFILE
         logMessage 2 $LOGFILE "Partial Backup: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     else
-        SNAP_NAME="@$(date +"%F-%R-%s")-failed"
+        SNAP_NAME="@$(date +"%F-%T-%s")-failed"
         echo "failed" > $STATUSFILE
         logMessage 3 $LOGFILE "Backup failed: ${CMD}. Rsync exited with ${RSYNC_RETVAL}"
     fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -13,7 +13,7 @@ logMessage () {
     # $1 = Error level
     # $2 = logpath
     # $3 = message
-    DATE=$(date +"%F %R")
+    DATE=$(date +"%F %T")
     if [ "$1" -ge "$LOG_LEVEL" ]; then
         echo "$DATE $3" >> ${2}
         if [ "$ECHO_LOG" -eq "1" ]; then

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -13,7 +13,7 @@ logMessage () {
     # $1 = Error level
     # $2 = logpath
     # $3 = message
-    DATE=$(date +"%F %X")
+    DATE=$(date +"%F %R")
     if [ "$1" -ge "$LOG_LEVEL" ]; then
         echo "$DATE $3" >> ${2}
         if [ "$ECHO_LOG" -eq "1" ]; then


### PR DESCRIPTION
Timestamp used in snapshot names was subject to locale specific settings which lead to ambiguous timestamps. This ensures a ISO style date/timestamp combo.