### PR TITLE
backup-runner accepts the expiry argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ or multiple hosts
 
 ``./bin/backup-runner.sh <hostname> <hostname>...``
 
+### Running scheduled backups with flexible retention
+You can configure cron jobs to run regular backups with flexible retentions.
+
+The following example keeps daily backups for 2 weeks, weekly backups for 6 months and monthly backups for a year.
+
+```
+# daily backups, kept for 2 weeks
+00 2 2-31 * * test $(date +\%u) != 7 && /backup/bin/backup-runner.sh --all --comment "Daily backup" --expiry 14 && /backup/bin/prune.sh --all
+# weekly backups, kept for 6 months
+00 2 2-31 * * test $(date +\%u) = 7 && /backup/bin/backup-runner.sh --all --comment "Weekly backup" --expiry 180 && /backup/bin/prune.sh --all
+# monthly backups, kept for a year
+00 2 1 * * /backup/bin/backup-runner.sh --all --comment "Monthly backup" --expiry 365 && /backup/bin/prune.sh --all
+```
+
 ### Restoring (ZFS)
 
 All backups are stored on disk in plain sight. To restore all you need to do

--- a/bin/backup-runner.sh
+++ b/bin/backup-runner.sh
@@ -50,6 +50,7 @@ while true; do
     case "$1" in
         -a | --all ) HOSTS=$(ls ${HOSTS_DIR}); shift ;;
         -c | --comment ) ANNOTATION=$2; shift 2 ;;
+        -e | --expiry ) EXPIRY=$2; shift 2 ;;
         -h | --help ) showUsage; exit 128 ;;
         -- ) shift; break ;;
         * ) if [ ! "$1" == "" ]; then HOSTS="$HOSTS $*"; fi; shift; break ;;
@@ -66,7 +67,7 @@ logMessage 1 $LOGFILE "Info: Begin backup run of hosts $(echo ${HOSTS})"
 
 for host in $HOSTS; do
     logMessage 1 $LOGFILE "Info: Begining backup of ${host}" 
-    ${CWD}backup.sh ${host} "${ANNOTATION}"
+    ${CWD}backup.sh ${host} "${ANNOTATION}" ${EXPIRY}
     if [ "$?" = "0" ]; then
         logMessage 1 $LOGFILE "Info: Completed backup of ${host}" 
     else


### PR DESCRIPTION
Hi,

I extended the backup-runner.sh to accept the EXPIRY argument so a flexible retention setup can be configured with the proper cron jobs. See the README for an example.