### PR TITLE
Feature/disable double alert

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -143,7 +143,7 @@ if [ "$RSYNC_RETVAL" = "0" ] || [ "${SNAPSHOT_ON_ERROR}" == "true" ]; then
     if [ "$RSYNC_RETVAL" = "0" ] && [ "$SNAPSHOT_RETVAL" = "0" ]; then
         if [ "$MONITOR_ENABLED" == "true" ]; then
             $MONITOR_HANDLER "backup ${HOST}" 0 "Backup Successful. Runtime ${RUNTIME} seconds."
-            $MONITOR_HANDLER "${ANNOTATION}" 0 "Backup Successful. Runtime ${RUNTIME} seconds." ${HOST}
+            [ "$MONITOR_HOST_CHECK_ENABLED" == "true" ] && $MONITOR_HANDLER "${ANNOTATION}" 0 "Backup Successful. Runtime ${RUNTIME} seconds." ${HOST}
         fi
         logMessage 1 $LOGFILE "Backup Successful. Runtime ${RUNTIME} seconds."
     elif [ "$RSYNC_RETVAL" = "0" ] && [ "$SNAPSHOT_RETVAL" != "0" ]; then
@@ -156,14 +156,14 @@ if [ "$RSYNC_RETVAL" = "0" ] || [ "${SNAPSHOT_ON_ERROR}" == "true" ]; then
         if [ "$MONITOR_ENABLED" == "true" ]; then
             # Downgrade rsync failure error to warning (1) (because SNAPSHOT_ON_ERROR=true)
             $MONITOR_HANDLER "backup ${HOST}" 1 "Backup Failed: ${CMD}. Snapshotted anyway."
-            $MONITOR_HANDLER "${ANNOTATION}" 1 "Backup Failed: ${CMD}. Snapshotted anyway." ${HOST}
+            [ "$MONITOR_HOST_CHECK_ENABLED" == "true" ] && $MONITOR_HANDLER "${ANNOTATION}" 1 "Backup Failed: ${CMD}. Snapshotted anyway." ${HOST}
         fi
         exit 99
     fi
 else
     if [ "$MONITOR_ENABLED" == "true" ]; then
         $MONITOR_HANDLER "backup ${HOST}" 2 "Backup Failed: ${CMD}."
-        $MONITOR_HANDLER "${ANNOTATION}" 2 "Backup Failed: ${CMD}." ${HOST}
+        [ "$MONITOR_HOST_CHECK_ENABLED" == "true" ] && $MONITOR_HANDLER "${ANNOTATION}" 2 "Backup Failed: ${CMD}." ${HOST}
     fi
     logMessage 3 $LOGFILE "Backup Failed: ${CMD}. Rsync exited with ${RSYNC_RETVAL}."
     echo "failed" > $STATUSFILE

--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -3,8 +3,8 @@
 # Adlibre Backup - monitor
 
 # Sends process status information to Nagios / Icinga using NSCA passive check
-# Replace this with your own monitor script to integrate with any third party
-# monitoring system.
+# Specify MONITOR_HANDLER to replace this with your own monitor script
+# to integrate with any third party monitoring system.
 
 CWD="$(dirname $0)/"
 

--- a/bin/test-alerts.sh
+++ b/bin/test-alerts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Adlibre Backup - Test NSCA Alerts
+# Adlibre Backup - Test Alert Handler
 
 CWD="$(dirname $0)/"
 

--- a/etc/backup.conf
+++ b/etc/backup.conf
@@ -17,4 +17,5 @@ PRUNE=true  # Prune old expired backup snapshots
 
 # monitoring configuration
 MONITOR_ENABLED='false'  # true or false
-MONITOR_HANDLER="$(dirname $0)/../bin/monitor.sh"
+MONITOR_HOST_CHECK_ENABLED='true'  # send a double check. one for the backup host, and one for each host that is backed up.
+MONITOR_HANDLER="$(dirname $0)/../bin/monitor.sh"  # default handler: supports nsca


### PR DESCRIPTION
Optionally disable sending a check result for the host that is backed up as well as the backup node. Requires setting `MONITOR_HOST_CHECK_ENABLED` `true` / `false` in `etc/backup.cfg`.